### PR TITLE
Fix Perl-5.20.0 build test error

### DIFF
--- a/lib/Config/ENV.pm
+++ b/lib/Config/ENV.pm
@@ -60,9 +60,10 @@ sub config ($$) { ## no critic
 sub load ($) { ## no critic
 	my $filename = shift;
 	my $hash = do "$filename";
+	my $errno = $!;
 
 	croak $@ if $@;
-	croak $! unless defined $hash;
+	croak $errno unless defined $hash;
 	unless (ref($hash) eq 'HASH') {
 		croak "$filename does not return HashRef.";
 	}


### PR DESCRIPTION
Cause build error using perl 5.20.0. bacause of failed 1 test script (05_load.t).
Fix `$!` value set local variable `my $errno`.

maybe from 5.20.0, `$!` handling changing...?
