### PR TITLE
local config is broken when localize guard object has released in a different order

### DIFF
--- a/lib/Config/ENV.pm
+++ b/lib/Config/ENV.pm
@@ -101,16 +101,7 @@ sub local {
 	undef $data->{_merged};
 
 	bless sub {
-		%hash = ();
-
-		# cleanup $data->{_local}
-		my $threshold;
-		for my $i (reverse 0..$#{ $data->{_local} }) {
-			last if %{ $data->{_local}->[$i] };
-			$threshold = $i;
-		}
-		splice @{ $data->{_local} }, -(@{ $data->{_local} } - $threshold) if defined $threshold;
-
+		@{ $data->{_local} } = grep { $_ != \%hash } @{ $data->{_local} };
 		undef $data->{_merged};
 	}, 'Config::ENV::Local';
 }

--- a/t/04_local.t
+++ b/t/04_local.t
@@ -76,7 +76,7 @@ is config->param('name'), 'foobar';
 
 	undef $guard2;
 	is config->param('name'), 'localized3';
-	is @{ config->_data->{_local} }, 3 if $ENV{AUTHOR_TESTING};
+	is @{ config->_data->{_local} }, 2 if $ENV{AUTHOR_TESTING};
 
 	undef $guard3;
 	is config->param('name'), 'localized1';

--- a/t/04_local.t
+++ b/t/04_local.t
@@ -59,6 +59,34 @@ is config->param('name'), 'foobar';
 	is config->param('name'), 'localized';
 };
 
+{
+	is @{ config->_data->{_local} }, 0 if $ENV{AUTHOR_TESTING};
+
+	my $guard1 = config->local(name => 'localized1');
+	is config->param('name'), 'localized1';
+	is @{ config->_data->{_local} }, 1 if $ENV{AUTHOR_TESTING};
+
+	my $guard2 = config->local(name => 'localized2');
+	is config->param('name'), 'localized2';
+	is @{ config->_data->{_local} }, 2 if $ENV{AUTHOR_TESTING};
+
+	my $guard3 = config->local(name => 'localized3');
+	is config->param('name'), 'localized3';
+	is @{ config->_data->{_local} }, 3 if $ENV{AUTHOR_TESTING};
+
+	undef $guard2;
+	is config->param('name'), 'localized3';
+	is @{ config->_data->{_local} }, 3 if $ENV{AUTHOR_TESTING};
+
+	undef $guard3;
+	is config->param('name'), 'localized1';
+	is @{ config->_data->{_local} }, 1 if $ENV{AUTHOR_TESTING};
+
+	undef $guard1;
+	is config->param('name'), 'foobar';
+	is @{ config->_data->{_local} }, 0 if $ENV{AUTHOR_TESTING};
+};
+
 like exception { config->local(name => 'localized'); undef }, qr/local returns guard object; Can't use in void context/;
 
 done_testing;


### PR DESCRIPTION
`local` guard object breaks config data at following case:
```perl
my $guard1 = config->local(name => 'localized1');
config->param('name'); # localized1
my $guard2 = config->local(name => 'localized2');
config->param('name'); # localized2
my $guard3 = config->local(name => 'localized3');
config->param('name'); # localized3
undef $guard2;
config->param('name'); # localized2 (!?)
undef $guard3;
config->param('name'); # localized1 (!?)
```