### PR TITLE
Improve error messages

### DIFF
--- a/lib/Config/ENV.pm
+++ b/lib/Config/ENV.pm
@@ -68,7 +68,7 @@ sub load ($) { ## no critic
 	my $hash = do "$explicit_filename";
 
 	croak $@ if $@;
-	croak $^E unless defined $hash;
+	croak "$^E" unless defined $hash;
 	unless (ref($hash) eq 'HASH') {
 		croak "$filename does not return HashRef.";
 	}

--- a/lib/Config/ENV.pm
+++ b/lib/Config/ENV.pm
@@ -61,8 +61,11 @@ sub config ($$) { ## no critic
 
 sub load ($) { ## no critic
 	my $filename = shift;
-	$filename = File::Spec->catfile('.', $filename) unless File::Spec->file_name_is_absolute($filename);
-	my $hash = do "$filename";
+
+	# Workaround: convert implied relative path to explicit path for CVE-2016-1238 (. in @INC removal)
+	my $explicit_filename = $filename;
+	$explicit_filename = File::Spec->catfile('.', $filename) unless File::Spec->file_name_is_absolute($filename);
+	my $hash = do "$explicit_filename";
 
 	croak $@ if $@;
 	croak $^E unless defined $hash;

--- a/t/05_load.t
+++ b/t/05_load.t
@@ -9,6 +9,7 @@ use Errno ();
 use File::Spec;
 
 is int(do{local ($!, $@); eval{ load('unknown_file') }; $!}), Errno::ENOENT;
+like exception { load('unknown_file') }, qr{No such file or directory};
 like exception { load('t/data/parse_error.pl') }, qr{syntax error at .* line 2, near ";;"};
 like exception { load('t/data/no_values.pl') }, qr{\At/data/no_values.pl does not return HashRef.};
 is exception { load('t/data/valid.pl') }, undef;

--- a/t/05_load.t
+++ b/t/05_load.t
@@ -10,7 +10,7 @@ use File::Spec;
 
 is int(do{local ($!, $@); eval{ load('unknown_file') }; $!}), Errno::ENOENT;
 like exception { load('t/data/parse_error.pl') }, qr{syntax error at .* line 2, near ";;"};
-like exception { load('t/data/no_values.pl') }, qr{t/data/no_values.pl does not return HashRef.};
+like exception { load('t/data/no_values.pl') }, qr{\At/data/no_values.pl does not return HashRef.};
 is exception { load('t/data/valid.pl') }, undef;
 
 my $rel_path = 't/data/valid.pl';


### PR DESCRIPTION
No error was displayed when the config file couldn't be read.
```perl
use Config::ENV;
load('unknown_file');
```
before:
```
 at lib/Config/ENV.pm line 68.
        Config::ENV::load("unknown_file") called at test.pl line 5
```
after:
```
No such file or directory at lib/Config/ENV.pm line 71.
        Config::ENV::load("unknown_file") called at test.pl line 5
```
---
Restored to previous behavior in Config::ENV <= 0.16. This was chaged by #10.
```perl
use Config::ENV;
load('t/data/no_values.pl');
```
before (Config::ENV 0.17):
```
./t/data/no_values.pl does not return HashRef. at lib/Config/ENV.pm line 69.
        Config::ENV::load("t/data/no_values.pl") called at test.pl line 4
```
after:
```
t/data/no_values.pl does not return HashRef. at lib/Config/ENV.pm line 72.
        Config::ENV::load("t/data/no_values.pl") called at test.pl line 4
```