### PR TITLE
Fix test for mswin32

### DIFF
--- a/t/05_load.t
+++ b/t/05_load.t
@@ -9,7 +9,7 @@ use Errno ();
 use File::Spec;
 
 is int(do{local ($!, $@); eval{ load('unknown_file') }; $!}), Errno::ENOENT;
-like exception { load('t/data/parse_error.pl') }, qr{syntax error at ./t/data/parse_error.pl line 2, near ";;"};
+like exception { load('t/data/parse_error.pl') }, qr{syntax error at .* line 2, near ";;"};
 like exception { load('t/data/no_values.pl') }, qr{t/data/no_values.pl does not return HashRef.};
 is exception { load('t/data/valid.pl') }, undef;
 


### PR DESCRIPTION
This fixes test failure on mswin32: http://matrix.cpantesters.org/?dist=Config-ENV+0.17
