### PR TITLE
Make sure error isn't empty because $^E varies by OS/locale

### DIFF
--- a/t/05_load.t
+++ b/t/05_load.t
@@ -9,7 +9,7 @@ use Errno ();
 use File::Spec;
 
 is int(do{local ($!, $@); eval{ load('unknown_file') }; $!}), Errno::ENOENT;
-like exception { load('unknown_file') }, qr{No such file or directory};
+like exception { load('unknown_file') }, qr{\A.+ at .* line};
 like exception { load('t/data/parse_error.pl') }, qr{syntax error at .* line 2, near ";;"};
 like exception { load('t/data/no_values.pl') }, qr{\At/data/no_values.pl does not return HashRef.};
 is exception { load('t/data/valid.pl') }, undef;


### PR DESCRIPTION
Fixed #13, the test added by #11 was failed in some environments: http://matrix.cpantesters.org/?dist=Config-ENV+0.18