### PR TITLE
Remove Exporter::Lite from dependencies

### DIFF
--- a/META.json
+++ b/META.json
@@ -47,11 +47,6 @@
             "Test::Pod" : "1.41",
             "Test::Spellunker" : "v0.2.7"
          }
-      },
-      "runtime" : {
-         "requires" : {
-            "Exporter::Lite" : "0"
-         }
       }
    },
    "release_status" : "unstable",

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,3 @@
-requires 'Exporter::Lite';
-
 on build => sub {
     requires 'ExtUtils::MakeMaker', '6.36';
     requires 'Test::Fatal';


### PR DESCRIPTION
The current `Config::ENV` includes `Exporter::Lite` as a dependency, but `Exporter::Lite` is not used from anywhere, so it was removed.